### PR TITLE
fix useless argument

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       const [_, queryString] = search.split('?')
       const params = new URLSearchParams(queryString)
 
-      const isValidSpeed = isNumberString(params.get('speed')) && parseFloat(params.get('speed'), 10) > 0
+      const isValidSpeed = isNumberString(params.get('speed')) && parseFloat(params.get('speed')) > 0
       if (params.has('speed') && !isValidSpeed) {
         console.error(`speed '${params.get('speed')}' is invalid value. It must be a positive number bigger than 0`)
       }


### PR DESCRIPTION
`parseFloat` does not take second argument.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat